### PR TITLE
Use semantic markup for the checkbox label

### DIFF
--- a/cmd/wasm/assets/index.html
+++ b/cmd/wasm/assets/index.html
@@ -21,7 +21,7 @@
     <tr>
       <td>Hint count: <input size="3" id="hintcount" value="30"></input></td>
       <td class="spacerheader"></td>
-      <td><input type="checkbox" id="symmetrical">Symmetrical</input></td>
+      <td><input type="checkbox" id="symmetrical"><label for="symmetrical">Symmetrical</label></input></td>
       <td class="spacerheader"></td>
       <td><button id="generate" title="Generate puzzle">Generate</button></td>
     </tr>


### PR DESCRIPTION
Checkbox labels that don't interact with the checkbox are a pet peeve, so I just had to fix it. It's also a popular dark pattern when the presenter doesn't want you to toggle the checkbox (e.g. turning off telemetry in Edge, etc.).